### PR TITLE
Adding runtime to babel transformer as per babel docs

### DIFF
--- a/wallaby.js
+++ b/wallaby.js
@@ -11,7 +11,7 @@ module.exports = function (wallaby) {
         ],
 
         preprocessors: {
-            '**/*.js': file => require('babel').transform(file.content, {sourceMap: true})
+            '**/*.js': file => require('babel').transform(file.content, {sourceMap: true, optional: ["runtime"] })
         },
 
         env: {

--- a/wallaby.js
+++ b/wallaby.js
@@ -11,6 +11,12 @@ module.exports = function (wallaby) {
         ],
 
         preprocessors: {
+            // NOTE: If you're using Babel 6, you should use `presets: ['es2015']`.
+            // You will also need to
+            // npm install babel-core (and require it instead of babel)
+            // and
+            // npm install babel-preset-es2015
+            // See http://babeljs.io/docs/plugins/preset-es2015/
             '**/*.js': file => require('babel').transform(file.content, {sourceMap: true, optional: ["runtime"] })
         },
 

--- a/wallaby.js
+++ b/wallaby.js
@@ -31,10 +31,6 @@ module.exports = function (wallaby) {
                 runner: '--harmony',
                 env: 'PARAM1=true;PARAM2=false'
             }
-        },
-
-        bootstrap: function () {
-            global.regeneratorRuntime = require('babel-runtime/regenerator').default;
         }
     }
 };


### PR DESCRIPTION
It looks like babel transform needs to include the runtime param - https://babeljs.io/docs/usage/runtime/
